### PR TITLE
[week6] DFS/BFS_이정우

### DIFF
--- a/정우/week6/게임 맵 최단거리.js
+++ b/정우/week6/게임 맵 최단거리.js
@@ -1,0 +1,28 @@
+function solution(maps) {
+  let answer = 0;
+  const dx = [0, 0, 1, -1];
+  const dy = [1, -1, 0, 0];
+  const x = maps[0].length - 1;
+  const y = maps.length - 1;
+  const queue = [[0, 0, 1]];
+
+  while (queue.length) {
+    const now = queue.shift();
+
+    if (now[0] === y && now[1] === x) {
+      return now[2];
+    }
+
+    for (let i = 0; i < 4; i++) {
+      const ny = now[0] + dy[i];
+      const nx = now[1] + dx[i];
+
+      if (nx >= 0 && nx <= x && ny >= 0 && ny <= y && maps[ny][nx] === 1) {
+        maps[ny][nx] = 0;
+        queue.push([ny, nx, now[2] + 1]);
+      }
+    }
+  }
+
+  return -1;
+}

--- a/정우/week6/타겟 넘버.js
+++ b/정우/week6/타겟 넘버.js
@@ -1,0 +1,23 @@
+let answer = 0;
+let global_numbers = [];
+let global_target = 0;
+
+function solution(numbers, target) {
+  global_numbers = numbers;
+  global_target = target;
+
+  dfs(0, 0);
+
+  return answer;
+}
+
+function dfs(depth, sum) {
+  if (depth < global_numbers.length) {
+    dfs(depth + 1, sum + global_numbers[depth]);
+    dfs(depth + 1, sum - global_numbers[depth]);
+  } else {
+    if (sum === global_target) {
+      answer += 1;
+    }
+  }
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[week n] 해당주차 주제(ex: 스택/큐)_이름 " 으로 작성해주시면 되겠습니다 -->

## ✨ 이번주 문제 풀이
- 타겟 넘버
깊이 depth가 numbers 배열 길이랑 같아질 때까지, 즉 numbers 배열을 다 검사할 때까지 계속 각 배열 요소를 sum에 더하고 빼보면서 dfs로 순차적으로 검사해나간다. depth가 numbers 배열 길이랑 같아진 순간 target 값이랑 sum 값이 같다면 target을 만드는 한 가지의 경우가 되므로 answer를 1 증가시킨다. 모든 경우의 수를 다 시도해보고 나온 answer의 총 결과값을 return하면 된다.

- 게임 맵 최단거리 (인터넷을 조금 참고하였습니다.....)
x와 y좌표의 이동 방향을 dx와 dy로 정의했다. x와 y는 게임 맵 크기이다. queue에 현재 상태를 넣고 빼고 하며 BFS를 수행한다. BFS에 사용하는 큐 item은 원소가 3개인 배열이다. 첫 번째 원소는 현재 x좌표, 두 번째 원소는 현재 y좌표, 세 번째 원소는 현재 단계 number이다. 이 배열 단위로 넣었다 뺐다 하는데 시작지점 queue 아이템은 x, y좌표가 0, 0이고 1단계이므로 [0, 0, 1]이 들어가있는 상태로 시작한다. 큐가 비어있지 않는 동안 계속 큐에서 아이템을 빼며 만약 뺀 아이템이 목적지다? 그러면 2번째 인덱스(현재 단계)를 리턴한다. 아니라면 위에 정의한 dx, dy를 사용해서 현재 위치에서 상 하 좌 우를 탐색한다. 이 중 맵 경계를 벗어나거나 이미 방문했다면 무시하고, 아니라면 현재 위치를 방문 표시하고 큐에 다음 가능한 위치와 현재 단계 + 1값을 queue에 push한다. 만약 큐가 텅 빌 동안 목적지에 도달하지 못하면 -1을 리턴한다.


<br />

## 📚 이번주 코테 공부 중 느낀점 / 배운 점
하..... 확실히 어렵습니다..... 문제가 길면 읽기부터 조금 두려워지는 듯 해요.....🥺 버릇을 고쳐야겠다고 생각했고 방식 자체는 우선순위 큐때보다는 좀 나은 것 같아서 충분히 구현할 수 있을 것 같다고 생각했습니다!!!

<br/>

## 📓 pr point! 요기를 집중해서 봐주세요-!

- 타겟 넘버 - 각 배열 요소마다 더하고 빼보는 시도를 재귀적으로 수행하는 DFS 부분입니다. (흠 근데 이거 풀 때 DFS 함수를 메인 함수에서 분리하는 바람에 메인 함수 파라미터를 전역변수로 옮기고 참조했는데, 생각해보니 DFS 함수를 메인 함수 안으로 넣어서 쓰면 이럴 필요가 없을지도...?)
```js
function dfs(depth, sum) {
  if (depth < global_numbers.length) {
    dfs(depth + 1, sum + global_numbers[depth]);
    dfs(depth + 1, sum - global_numbers[depth]);
  } else {
    if (sum === global_target) {
      answer += 1;
    }
  }
}
```

- 게임 맵 최단거리 - 상하좌우 부분으로 가능한 경우의 수를 다 검사해보는 BFS 부분입니다!! 자세한 설명은 위 문제 해결 설명 참고!!!
```js
for (let i = 0; i < 4; i++) {
      const ny = now[0] + dy[i];
      const nx = now[1] + dx[i];

      if (nx >= 0 && nx <= x && ny >= 0 && ny <= y && maps[ny][nx] === 1) {
        maps[ny][nx] = 0;
        queue.push([ny, nx, now[2] + 1]);
      }
    }
```
